### PR TITLE
기록 측정 방식에 따른 순위 정렬 코드 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.40.0",
         "@tanstack/react-query": "^5.28.14",
         "@types/dompurify": "^3.0.5",
+        "@types/lodash": "^4.17.7",
         "axios": "^1.7.2",
         "dayjs": "^1.11.10",
         "dompurify": "^3.1.0",
@@ -1447,6 +1448,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA=="
     },
     "node_modules/@types/node": {
       "version": "20.11.30",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.40.0",
     "@tanstack/react-query": "^5.28.14",
     "@types/dompurify": "^3.0.5",
+    "@types/lodash": "^4.17.7",
     "axios": "^1.7.2",
     "dayjs": "^1.11.10",
     "dompurify": "^3.1.0",

--- a/src/api/supabase/supabase.d.ts
+++ b/src/api/supabase/supabase.d.ts
@@ -81,7 +81,9 @@ export type Database = {
           createdDate: string;
           id: number;
           name: string;
-          record: number;
+          record: string;
+          recordType: string;
+          sortableRecord: number;
           workoutType: string;
           writerUuid: string;
         };
@@ -89,7 +91,9 @@ export type Database = {
           createdDate?: string;
           id?: number;
           name: string;
-          record: number;
+          record: string;
+          recordType: string;
+          sortableRecord: number;
           workoutType: string;
           writerUuid: string;
         };
@@ -97,7 +101,9 @@ export type Database = {
           createdDate?: string;
           id?: number;
           name?: string;
-          record?: number;
+          record?: string;
+          recordType?: string;
+          sortableRecord?: number;
           workoutType?: string;
           writerUuid?: string;
         };

--- a/src/components/common/RecordTable.tsx
+++ b/src/components/common/RecordTable.tsx
@@ -10,29 +10,22 @@ const RecordTable = ({
   records: Record[];
 }) => {
   // Record table header
-  const columnTitles = ["순위", "이름", "기록", "Rx’d/Scaled"];
+  const columnTitles = ["순위", "이름", "기록"];
 
   // Record table body
   const renderBody = (records: Record[]) => (
     <tbody>
-      {records
-        .sort((a, b) => {
-          const aRecord = a.record ?? 0;
-          const bRecord = b.record ?? 0;
-          return bRecord - aRecord;
-        })
-        .map((record, index) => (
-          <tr key={record.id}>
-            <td>{index + 1}</td>
-            <td>{record.name}</td>
-            <td>
-              {record.record && !Number.isInteger(record.record)
-                ? record.record.toString().replace(".", "R + ")
-                : record.record}
-            </td>
-            <td>{record.workoutType}</td>
-          </tr>
-        ))}
+      {records.map((record, index) => (
+        <tr key={record.id}>
+          <td>{index + 1}</td>
+          <td>{record.name}</td>
+          <td>
+            {record.recordType === "unrecognizable"
+              ? `기록 추출 시도 실패: ${record.record}`
+              : record.record}
+          </td>
+        </tr>
+      ))}
     </tbody>
   );
 

--- a/src/pages/Record/RecordList.tsx
+++ b/src/pages/Record/RecordList.tsx
@@ -10,22 +10,64 @@ import { Record } from "../../types/type";
 import { userInfoAtom } from "../../store/atoms";
 import { useAtomValue } from "jotai";
 import { recordQueryKeys } from "../../queries/recordQueries";
+import { useMemo } from "react";
+
+type GroupedRecords = { [key: string]: Record[] };
+
+const workoutTypeOrder = ["Rx’d", "A", "B", "C"];
+const recordTypeOrder = ["time", "round", "number", "unrecognizable"];
 
 const RecordList = () => {
   const userInfo = useAtomValue(userInfoAtom);
   const { data: records } = useSuspenseQuery(recordQueryKeys.list());
 
-  const groupedRecords = records?.reduce((acc, record) => {
-    if (!acc[record.workoutType]) {
-      acc[record.workoutType] = [];
-    }
-    acc[record.workoutType].push(record);
-    return acc;
-  }, {} as { [key: string]: Record[] });
+  const groupedAndSortedRecords = useMemo(() => {
+    // workoutType 별로 records 그룹화
+    const groupedRecords = records.reduce((acc: GroupedRecords, record) => {
+      if (!acc[record.workoutType]) {
+        acc[record.workoutType] = [];
+      }
+      acc[record.workoutType].push(record);
+      return acc;
+    }, {});
 
-  const sortedRecords = ["Rx’d", "A", "B", "C"]
-    .filter((type) => groupedRecords && groupedRecords[type])
-    .map((type) => [type, groupedRecords[type]] as [string, Record[]]);
+    // workoutType 내에서 records를 정렬
+    Object.keys(groupedRecords).forEach((workoutType) => {
+      groupedRecords[workoutType].sort((a, b) => {
+        // recordType 순서 비교
+        const typeComparison =
+          recordTypeOrder.indexOf(a.recordType) -
+          recordTypeOrder.indexOf(b.recordType);
+        if (typeComparison !== 0) return typeComparison;
+
+        // recordType이 같은 경우, sortableRecord 값으로 정렬
+        // time 오름차순, round 및 number 내림차순
+        return a.recordType === "time"
+          ? a.sortableRecord - b.sortableRecord
+          : b.sortableRecord - a.sortableRecord;
+      });
+    });
+    return groupedRecords;
+  }, [records]);
+
+  // 존재하는 workoutType만 화면에 보여줌
+  const sortedWorkoutTypes = workoutTypeOrder
+    .filter((type) => groupedAndSortedRecords[type])
+    .map((type) => [type, groupedAndSortedRecords[type]] as [string, Record[]]);
+
+  const renderRecordTables = (start: number, end: number) => (
+    <div className={`record_grade_${start + 1}`}>
+      {sortedWorkoutTypes
+        .slice(start, end)
+        .map(([workoutType, workoutRecords]) => (
+          <RecordTable
+            key={workoutType}
+            workoutType={workoutType}
+            records={workoutRecords}
+          />
+        ))}
+    </div>
+  );
 
   return (
     <div className="wrapper">
@@ -33,28 +75,8 @@ const RecordList = () => {
       <div className="record_grade">
         {records && records.length > 0 ? (
           <>
-            <div className="record_grade_1">
-              {sortedRecords
-                .slice(0, 2)
-                .map(([workoutType, workoutRecords]) => (
-                  <RecordTable
-                    key={workoutType}
-                    workoutType={workoutType}
-                    records={workoutRecords}
-                  />
-                ))}
-            </div>
-            <div className="record_grade_2">
-              {sortedRecords
-                .slice(2, 4)
-                .map(([workoutType, workoutRecords]) => (
-                  <RecordTable
-                    key={workoutType}
-                    workoutType={workoutType}
-                    records={workoutRecords}
-                  />
-                ))}
-            </div>
+            {renderRecordTables(0, 2)}
+            {renderRecordTables(2, 4)}
           </>
         ) : (
           <NoPost post="Record" />

--- a/src/pages/Record/RecordList.tsx
+++ b/src/pages/Record/RecordList.tsx
@@ -23,16 +23,13 @@ const RecordList = () => {
 
   const groupedAndSortedRecords = useMemo(() => {
     // workoutType 별로 records 그룹화
-    const groupedRecords = records.reduce((acc: GroupedRecords, record) => {
-      if (!acc[record.workoutType]) {
-        acc[record.workoutType] = [];
-      }
-      acc[record.workoutType].push(record);
-      return acc;
-    }, {});
+    const groupedRecords = Object.groupBy(
+      records,
+      ({ workoutType }) => workoutType
+    ) as GroupedRecords;
 
-    // workoutType 내에서 records를 정렬
-    Object.keys(groupedRecords).forEach((workoutType) => {
+    // 각 workoutType 그룹 내에서 records를 정렬
+    for (const workoutType in groupedRecords) {
       groupedRecords[workoutType].sort((a, b) => {
         // recordType 순서 비교
         const typeComparison =
@@ -46,7 +43,7 @@ const RecordList = () => {
           ? a.sortableRecord - b.sortableRecord
           : b.sortableRecord - a.sortableRecord;
       });
-    });
+    }
     return groupedRecords;
   }, [records]);
 

--- a/src/pages/Record/RecordList.tsx
+++ b/src/pages/Record/RecordList.tsx
@@ -11,8 +11,7 @@ import { userInfoAtom } from "../../store/atoms";
 import { useAtomValue } from "jotai";
 import { recordQueryKeys } from "../../queries/recordQueries";
 import { useMemo } from "react";
-
-type GroupedRecords = { [key: string]: Record[] };
+import groupBy from "lodash/groupBy";
 
 const workoutTypeOrder = ["Rx’d", "A", "B", "C"];
 const recordTypeOrder = ["time", "round", "number", "unrecognizable"];
@@ -23,10 +22,7 @@ const RecordList = () => {
 
   const groupedAndSortedRecords = useMemo(() => {
     // workoutType 별로 records 그룹화
-    const groupedRecords = Object.groupBy(
-      records,
-      ({ workoutType }) => workoutType
-    ) as GroupedRecords;
+    const groupedRecords = groupBy(records, "workoutType");
 
     // 각 workoutType 그룹 내에서 records를 정렬
     for (const workoutType in groupedRecords) {

--- a/src/pages/Record/RecordList.tsx
+++ b/src/pages/Record/RecordList.tsx
@@ -25,7 +25,7 @@ const RecordList = () => {
     const groupedRecords = groupBy(records, "workoutType");
 
     // 각 workoutType 그룹 내에서 records를 정렬
-    for (const workoutType in groupedRecords) {
+    Object.keys(groupedRecords).forEach((workoutType) =>
       groupedRecords[workoutType].sort((a, b) => {
         // recordType 순서 비교
         const typeComparison =
@@ -38,8 +38,8 @@ const RecordList = () => {
         return a.recordType === "time"
           ? a.sortableRecord - b.sortableRecord
           : b.sortableRecord - a.sortableRecord;
-      });
-    }
+      })
+    );
     return groupedRecords;
   }, [records]);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Issue Number
#20

## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] 기능개발
- [x] 리팩토링

## 요약
- 기존 코드는 라운드와 개수만 등록 가능했기에 시간도 기록 측정 방식에 포함
- 기록 측정 방식을 시간(`time`), 라운드(`round`), 개수(`number`), 인식불가(`unrecognizable`)로 정의
- 시간은 짧은 순, 라운드는 많은 라운드 순, 개수는 많은 개수 순으로 정렬
- 기록 측정 방식이 혼재되어 있는 경우 시간, 라운드, 개수, 인식불가 순으로 정렬 
   e.g. 200, 3R+12, 3R, 17:17, 12+13 -> 17:17, 3R+12, 3R, 200, 12+13 순으로 정렬
- 기존 사용했던 포맷팅 방법 변경

## 상세 내용
- 기존 코드는 '3R+12'의 경우, '3.12'로 DB에 저장하여 화면 렌더링 시 소수인지 정수인지 판단해 `replace()`로 `.`을 `R+`로 변경
=>  자바스크립트는 부동소수점을 사용하기에 결과가 정확하지 않을 수 있어 정수로 변경
- 수정된 코드는 추출된 기록에 `R`이 있을 경우 1000을 곱하여 계산, `:`가 있을 경우 60을 곱하여 계산

<img width="896" alt="image" src="https://github.com/user-attachments/assets/6ce25421-3be1-431b-ab6f-b4377aac9cd8">
